### PR TITLE
Treat sphinx warnings as errors

### DIFF
--- a/doc_builder/build_docs.py
+++ b/doc_builder/build_docs.py
@@ -98,6 +98,9 @@ based on the version indicated by the current branch, is:
                         help="Number of parallel jobs to use for the make process.\n"
                         "Default is 4.")
 
+    parser.add_argument("-w", "--warnings-as-warnings", action="store_true",
+                        help="Treat sphinx warnings as warnings, not errors.")
+
     options = parser.parse_args(cmdline_args)
     return options
 
@@ -172,5 +175,7 @@ def main(cmdline_args=None):
                                           run_from_dir=os.getcwd(),
                                           build_target=opts.build_target,
                                           num_make_jobs=opts.num_make_jobs,
-                                          docker_name=docker_name)
+                                          docker_name=docker_name,
+                                          warnings_as_warnings=opts.warnings_as_warnings,
+                                          )
         run_build_command(build_command=build_command)


### PR DESCRIPTION
This PR makes it so that, by default, the sphinx command called (via the Makefile) by `build_docs` treats warnings as errors. The build will still complete, but the exit code will be 1 instead of 0, and the "The HTML pages are in" message won't appear.

Users can disable this behavior with the new `-w`/`--warnings-as-warnings` flag.

Tested in the CTSM repo with deliberately-bad restructuredText (invalid references) with flags: `-d`, `-d -w`, `-w`, and neither. Additional independent testing would be smart, I think, as I was using a custom Docker container for the `-d` tests.