### PR TITLE
Use ctsm-docs container

### DIFF
--- a/doc_builder/build_commands.py
+++ b/doc_builder/build_commands.py
@@ -7,7 +7,7 @@ import pathlib
 from doc_builder import sys_utils
 
 # The Docker image used to build documentation via Docker
-DOCKER_IMAGE = "ghcr.io/ctsm/ctsm-docs"
+DOCKER_IMAGE = "ghcr.io/escomp/ctsm/ctsm-docs"
 
 # The path in Docker's filesystem where the user's home directory is mounted
 _DOCKER_HOME = "/home/user/mounted_home"

--- a/doc_builder/build_commands.py
+++ b/doc_builder/build_commands.py
@@ -7,7 +7,7 @@ import pathlib
 from doc_builder import sys_utils
 
 # The Docker image used to build documentation via Docker
-DOCKER_IMAGE = "ctsm-docs-test10"
+DOCKER_IMAGE = "ctsm-docs-testalpine-01"
 
 # The path in Docker's filesystem where the user's home directory is mounted
 _DOCKER_HOME = "/home/user/mounted_home"

--- a/doc_builder/build_commands.py
+++ b/doc_builder/build_commands.py
@@ -7,7 +7,7 @@ import pathlib
 from doc_builder import sys_utils
 
 # The Docker image used to build documentation via Docker
-DOCKER_IMAGE = "ghcr.io/samsrabin/ctsm-docs-testalpine-03"
+DOCKER_IMAGE = "ghcr.io/ctsm/ctsm-docs"
 
 # The path in Docker's filesystem where the user's home directory is mounted
 _DOCKER_HOME = "/home/user/mounted_home"

--- a/doc_builder/build_commands.py
+++ b/doc_builder/build_commands.py
@@ -6,8 +6,7 @@ import os
 import pathlib
 from doc_builder import sys_utils
 
-# The Docker image used to build documentation via Docker
-DOCKER_IMAGE = "ghcr.io/escomp/ctsm/ctsm-docs"
+default_docker_image = "ghcr.io/escomp/ctsm/ctsm-docs"
 
 # The path in Docker's filesystem where the user's home directory is mounted
 _DOCKER_HOME = "/home/user/mounted_home"
@@ -65,7 +64,7 @@ command-line argument '--doc-version {version}'""".format(build_dir=build_dir,
     return build_dir
 
 def get_build_command(build_dir, run_from_dir, build_target, num_make_jobs, docker_name=None,
-                      warnings_as_warnings=False,
+                      warnings_as_warnings=False, docker_image=default_docker_image,
                       ):
     """Return a string giving the build command.
 
@@ -127,7 +126,7 @@ def get_build_command(build_dir, run_from_dir, build_target, num_make_jobs, dock
                       "--workdir", docker_workdir,
                       "-t",  # "-t" is needed for colorful output
                       "--rm",
-                      DOCKER_IMAGE] + make_command
+                      docker_image] + make_command
     return docker_command
 
 def _get_make_command(build_dir, build_target, num_make_jobs, warnings_as_warnings):

--- a/doc_builder/build_commands.py
+++ b/doc_builder/build_commands.py
@@ -7,7 +7,7 @@ import pathlib
 from doc_builder import sys_utils
 
 # The Docker image used to build documentation via Docker
-DOCKER_IMAGE = "ctsm-docs-test02"
+DOCKER_IMAGE = "ctsm-docs-test03"
 
 # The path in Docker's filesystem where the user's home directory is mounted
 _DOCKER_HOME = "/home/user/mounted_home"

--- a/doc_builder/build_commands.py
+++ b/doc_builder/build_commands.py
@@ -7,7 +7,7 @@ import pathlib
 from doc_builder import sys_utils
 
 # The Docker image used to build documentation via Docker
-DOCKER_IMAGE = "ctsm-docs-test04"
+DOCKER_IMAGE = "ctsm-docs-test05"
 
 # The path in Docker's filesystem where the user's home directory is mounted
 _DOCKER_HOME = "/home/user/mounted_home"

--- a/doc_builder/build_commands.py
+++ b/doc_builder/build_commands.py
@@ -109,6 +109,10 @@ def get_build_command(build_dir, run_from_dir, build_target, num_make_jobs, dock
         errmsg_if_not_under_mountpoint=
         "build directory must reside under your home directory")
 
+    # Get current user's UID and GID
+    uid = os.getuid()
+    gid = os.getgid()
+
     make_command = _get_make_command(build_dir=docker_build_dir,
                                      build_target=build_target,
                                      num_make_jobs=num_make_jobs,
@@ -117,6 +121,7 @@ def get_build_command(build_dir, run_from_dir, build_target, num_make_jobs, dock
 
     docker_command = ["docker", "run",
                       "--name", docker_name,
+                      "--user", f"{uid}:{gid}",
                       "--mount", "type=bind,source={},target={}".format(
                           docker_mountpoint, _DOCKER_HOME),
                       "--workdir", docker_workdir,

--- a/doc_builder/build_commands.py
+++ b/doc_builder/build_commands.py
@@ -7,7 +7,7 @@ import pathlib
 from doc_builder import sys_utils
 
 # The Docker image used to build documentation via Docker
-DOCKER_IMAGE = "ctsm-docs-testalpine-02"
+DOCKER_IMAGE = "ctsm-docs-testalpine-03"
 
 # The path in Docker's filesystem where the user's home directory is mounted
 _DOCKER_HOME = "/home/user/mounted_home"

--- a/doc_builder/build_commands.py
+++ b/doc_builder/build_commands.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 from doc_builder import sys_utils
 
-default_docker_image = "ghcr.io/escomp/ctsm/ctsm-docs"
+default_docker_image = "ghcr.io/escomp/ctsm/ctsm-docs:v1.0.0"
 
 # The path in Docker's filesystem where the user's home directory is mounted
 _DOCKER_HOME = "/home/user/mounted_home"

--- a/doc_builder/build_commands.py
+++ b/doc_builder/build_commands.py
@@ -7,7 +7,7 @@ import pathlib
 from doc_builder import sys_utils
 
 # The Docker image used to build documentation via Docker
-DOCKER_IMAGE = "ctsm-docs-test09"
+DOCKER_IMAGE = "ctsm-docs-test10"
 
 # The path in Docker's filesystem where the user's home directory is mounted
 _DOCKER_HOME = "/home/user/mounted_home"

--- a/doc_builder/build_commands.py
+++ b/doc_builder/build_commands.py
@@ -7,7 +7,7 @@ import pathlib
 from doc_builder import sys_utils
 
 # The Docker image used to build documentation via Docker
-DOCKER_IMAGE = "ctsm-docs-testalpine-01"
+DOCKER_IMAGE = "ctsm-docs-testalpine-02"
 
 # The path in Docker's filesystem where the user's home directory is mounted
 _DOCKER_HOME = "/home/user/mounted_home"

--- a/doc_builder/build_commands.py
+++ b/doc_builder/build_commands.py
@@ -7,7 +7,7 @@ import pathlib
 from doc_builder import sys_utils
 
 # The Docker image used to build documentation via Docker
-DOCKER_IMAGE = "ctsm-docs-test03"
+DOCKER_IMAGE = "ctsm-docs-test04"
 
 # The path in Docker's filesystem where the user's home directory is mounted
 _DOCKER_HOME = "/home/user/mounted_home"

--- a/doc_builder/build_commands.py
+++ b/doc_builder/build_commands.py
@@ -7,7 +7,7 @@ import pathlib
 from doc_builder import sys_utils
 
 # The Docker image used to build documentation via Docker
-DOCKER_IMAGE = "escomp/base"
+DOCKER_IMAGE = "ctsm-docs-test02"
 
 # The path in Docker's filesystem where the user's home directory is mounted
 _DOCKER_HOME = "/home/user/mounted_home"

--- a/doc_builder/build_commands.py
+++ b/doc_builder/build_commands.py
@@ -7,7 +7,7 @@ import pathlib
 from doc_builder import sys_utils
 
 # The Docker image used to build documentation via Docker
-DOCKER_IMAGE = "ctsm-docs-test05"
+DOCKER_IMAGE = "ctsm-docs-test09"
 
 # The path in Docker's filesystem where the user's home directory is mounted
 _DOCKER_HOME = "/home/user/mounted_home"

--- a/doc_builder/build_commands.py
+++ b/doc_builder/build_commands.py
@@ -7,7 +7,7 @@ import pathlib
 from doc_builder import sys_utils
 
 # The Docker image used to build documentation via Docker
-DOCKER_IMAGE = "ctsm-docs-testalpine-03"
+DOCKER_IMAGE = "ghcr.io/samsrabin/ctsm-docs-testalpine-03"
 
 # The path in Docker's filesystem where the user's home directory is mounted
 _DOCKER_HOME = "/home/user/mounted_home"

--- a/doc_builder/build_docs.py
+++ b/doc_builder/build_docs.py
@@ -9,7 +9,7 @@ import random
 import string
 import sys
 import signal
-from doc_builder.build_commands import get_build_dir, get_build_command, DOCKER_IMAGE
+from doc_builder.build_commands import get_build_dir, get_build_command, default_docker_image
 
 def commandline_options(cmdline_args=None):
     """Process the command-line arguments.
@@ -80,15 +80,23 @@ based on the version indicated by the current branch, is:
                         help="Before building, run 'make clean'.")
 
     parser.add_argument("-d", "--build-with-docker", action="store_true",
-                        help="Use the {docker_image} Docker container to build the documentation,\n"
+                        help="Use a Docker container to build the documentation,\n"
                         "rather than relying on locally-installed versions of Sphinx, etc.\n"
                         "This assumes that Docker is installed and running on your system.\n"
                         "\n"
                         "NOTE: This mounts your home directory in the Docker image.\n"
                         "Therefore, both the current directory (containing the Makefile for\n"
                         "building the documentation) and the documentation build directory\n"
-                        "must reside somewhere within your home directory.".format(
-                            docker_image=DOCKER_IMAGE))
+                        "must reside somewhere within your home directory."
+                        "\n"
+                        f"Default image: {default_docker_image}\n"
+                        "This can be changed with -i/--docker-image.")
+
+    parser.add_argument(
+        "-i", "--docker-image", "--docker-container",
+        default=default_docker_image,
+        help=f"Docker container to use. Implies -d. Default: {default_docker_image}"
+    )
 
     parser.add_argument("-t", "--build-target", default="html",
                         help="Target for the make command.\n"
@@ -102,6 +110,10 @@ based on the version indicated by the current branch, is:
                         help="Treat sphinx warnings as warnings, not errors.")
 
     options = parser.parse_args(cmdline_args)
+
+    if options.docker_image and not options.build_with_docker:
+        options.build_with_docker = True
+
     return options
 
 def run_build_command(build_command):
@@ -168,7 +180,8 @@ def main(cmdline_args=None):
                                               run_from_dir=os.getcwd(),
                                               build_target="clean",
                                               num_make_jobs=opts.num_make_jobs,
-                                              docker_name=docker_name)
+                                              docker_name=docker_name,
+                                              docker_image=opts.docker_image)
             run_build_command(build_command=clean_command)
 
         build_command = get_build_command(build_dir=build_dir,
@@ -176,6 +189,7 @@ def main(cmdline_args=None):
                                           build_target=opts.build_target,
                                           num_make_jobs=opts.num_make_jobs,
                                           docker_name=docker_name,
+                                          docker_image=opts.docker_image,
                                           warnings_as_warnings=opts.warnings_as_warnings,
                                           )
         run_build_command(build_command=build_command)

--- a/doc_builder/build_docs.py
+++ b/doc_builder/build_docs.py
@@ -111,7 +111,8 @@ based on the version indicated by the current branch, is:
 
     options = parser.parse_args(cmdline_args)
 
-    if options.docker_image and not options.build_with_docker:
+    if options.docker_image:
+        options.docker_image = options.docker_image.lower()
         options.build_with_docker = True
 
     return options

--- a/doc_builder/build_docs.py
+++ b/doc_builder/build_docs.py
@@ -94,8 +94,8 @@ based on the version indicated by the current branch, is:
 
     parser.add_argument(
         "-i", "--docker-image", "--docker-container",
-        default=default_docker_image,
-        help=f"Docker container to use. Implies -d. Default: {default_docker_image}"
+        default=None,
+        help="Docker container to use. Implies -d."
     )
 
     parser.add_argument("-t", "--build-target", default="html",
@@ -114,6 +114,8 @@ based on the version indicated by the current branch, is:
     if options.docker_image:
         options.docker_image = options.docker_image.lower()
         options.build_with_docker = True
+    elif options.build_with_docker:
+        options.docker_image = default_docker_image
 
     return options
 


### PR DESCRIPTION
Instead of using the huge [`escomp/base`](https://hub.docker.com/r/escomp/base) Docker container, use a smaller `ctsm-docs` container that also contains some additional Sphinx functionality.

Blocks ESCOMP/CTSM#2809.

Remaining work:
- [x] After pushing that container to GitHub, change `DOCKER_IMAGE =` line in `build_commands.py` to match the container name.
- [x] Tag it to use a specific hash or tag instead of latest