### PR TITLE
Add Podman support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This tool wraps the build command to build sphinx-based documentation.
 
 This tool assists with creating the correct documentation build commands
 in cases including:
-- Building the documentation from a Docker container
+- Building the documentation from a container
 - Building versioned documentation, where the documentation builds land
   in subdirectories named based on the source branch
 
@@ -16,7 +16,7 @@ Simple usage is:
 
     Common additional flags are:
     -c: Before building, run 'make clean'
-    -d: Use a Docker container to build the documentation
+    -d: Use a container to build the documentation
 
 Usage for automatically determining the subdirectory in which to build,
 based on the version indicated by the current branch, is:

--- a/build_docs_to_publish
+++ b/build_docs_to_publish
@@ -75,7 +75,7 @@ def checkout_and_build(version, args):
         args.site_root,
         "--clean",
     ]
-    if args.build_with_docker:
+    if args.build_in_container:
         build_args += ["-d"]
     if args.conf_py_path:
         build_args += ["--conf-py-path", args.conf_py_path]

--- a/doc_builder/build_commands.py
+++ b/doc_builder/build_commands.py
@@ -7,10 +7,10 @@ import pathlib
 import shutil
 from doc_builder import sys_utils  # pylint: disable=import-error
 
-DEFAULT_DOCKER_IMAGE = "ghcr.io/escomp/ctsm/ctsm-docs:v1.0.1"
+DEFAULT_IMAGE = "ghcr.io/escomp/ctsm/ctsm-docs:v1.0.1"
 
-# The path in Docker's filesystem where the user's home directory is mounted
-_DOCKER_HOME = "/home/user/mounted_home"
+# The path in the container's filesystem where the user's home directory is mounted
+_CONTAINER_HOME = "/home/user/mounted_home"
 
 # CLI tools we can try to use to run our container, in decreasing order of preference
 COMPATIBLE_CLI_TOOLS = ["podman", "docker"]
@@ -86,9 +86,9 @@ def get_build_command(
     build_target,
     version,
     num_make_jobs,
-    docker_name=None,
+    container_name=None,
     warnings_as_warnings=False,
-    docker_image=DEFAULT_DOCKER_IMAGE,
+    container_image=DEFAULT_IMAGE,
     conf_py_path=None,
     container_cli_tool=None,
 ):
@@ -99,13 +99,17 @@ def get_build_command(
     - build_dir: string giving path to directory in which we should build
         If this is a relative path, it is assumed to be relative to run_from_dir
     - run_from_dir: string giving absolute path from which the build_docs command was run
-        This is needed when using Docker
+        This is needed when using container
     - build_target: string: target for the make command (e.g., "html")
     - num_make_jobs: int: number of parallel jobs
-    - docker_name: string or None: if not None, uses a Docker container to do the build,
-        with the given name
+    - container_name: string or None: if not None, uses a container to do the build,
+        with the given name. This is just a temporary name that ensures we never have two active
+        containers with the same name.
+    - container_image: If using a container, this is the image that will be used (and downloaded,
+        if necessary). Typically named something like repository:version. See DEFAULT_IMAGE for an
+        example.
     """
-    if docker_name is None:
+    if container_name is None:
         return _get_make_command(
             build_dir=build_dir,
             build_target=build_target,
@@ -114,17 +118,17 @@ def get_build_command(
             conf_py_path=conf_py_path,
         )
 
-    # But if we're using Docker, we have more work to do to create the command....
+    # But if we're using a container, we have more work to do to create the command....
 
-    # Mount the user's home directory in the Docker image; this assumes that both
+    # Mount the user's home directory in the container; this assumes that both
     # run_from_dir and build_dir reside somewhere under the user's home directory (we
     # check this assumption below).
-    docker_mountpoint = os.path.expanduser("~")
+    container_mountpoint = os.path.expanduser("~")
 
     errmsg_if_not_under_mountpoint = "build_docs must be run from somewhere in your home directory"
-    docker_workdir = _docker_path_from_local_path(
+    container_workdir = _container_path_from_local_path(
         local_path=run_from_dir,
-        docker_mountpoint=docker_mountpoint,
+        container_mountpoint=container_mountpoint,
         errmsg_if_not_under_mountpoint=errmsg_if_not_under_mountpoint,
     )
 
@@ -132,9 +136,9 @@ def get_build_command(
         build_dir_abs = build_dir
     else:
         build_dir_abs = os.path.normpath(os.path.join(run_from_dir, build_dir))
-    docker_build_dir = _docker_path_from_local_path(
+    container_build_dir = _container_path_from_local_path(
         local_path=build_dir_abs,
-        docker_mountpoint=docker_mountpoint,
+        container_mountpoint=container_mountpoint,
         errmsg_if_not_under_mountpoint="build directory must reside under your home directory",
     )
 
@@ -143,7 +147,7 @@ def get_build_command(
     gid = os.getgid()
 
     make_command = _get_make_command(
-        build_dir=docker_build_dir,
+        build_dir=container_build_dir,
         build_target=build_target,
         num_make_jobs=num_make_jobs,
         warnings_as_warnings=warnings_as_warnings,
@@ -154,24 +158,24 @@ def get_build_command(
     if container_cli_tool is None:
         container_cli_tool = get_container_cli_tool()
 
-    docker_command = [
+    container_command = [
         container_cli_tool,
         "run",
         "--name",
-        docker_name,
+        container_name,
         "--user",
         f"{uid}:{gid}",
         "--mount",
-        f"type=bind,source={docker_mountpoint},target={_DOCKER_HOME}",
+        f"type=bind,source={container_mountpoint},target={_CONTAINER_HOME}",
         "--workdir",
-        docker_workdir,
+        container_workdir,
         "-t",  # "-t" is needed for colorful output
         "--rm",
         "-e",
         f"current_version={version}",
-        docker_image,
+        container_image,
     ] + make_command
-    return docker_command
+    return container_command
 
 
 def _get_make_command(build_dir, build_target, num_make_jobs, warnings_as_warnings, conf_py_path):
@@ -196,31 +200,33 @@ def _get_make_command(build_dir, build_target, num_make_jobs, warnings_as_warnin
     return ["make", sphinxopts, builddir_arg, "-j", str(num_make_jobs), build_target]
 
 
-def _docker_path_from_local_path(local_path, docker_mountpoint, errmsg_if_not_under_mountpoint):
-    """Given a path on the local file system, return the equivalent path in Docker space
+def _container_path_from_local_path(
+    local_path, container_mountpoint, errmsg_if_not_under_mountpoint
+):
+    """Given a path on the local file system, return the equivalent path in container space
 
     Args:
     - local_path: string: absolute path on local file system; this must reside under
-        docker_mountpoint
-    - docker_mountpoint: string: path on local file system that is mounted to _DOCKER_HOME
+        container_mountpoint
+    - container_mountpoint: string: path on local file system that is mounted to _CONTAINER_HOME
     - errmsg_if_not_under_mountpoint: string: message to print if local_path does not
-        reside under docker_mountpoint
+        reside under container_mountpoint
     """
     if not os.path.isabs(local_path):
         raise RuntimeError(f"Expect absolute path; got {local_path}")
 
     local_pathobj = pathlib.Path(local_path)
     try:
-        relpath = local_pathobj.relative_to(docker_mountpoint)
+        relpath = local_pathobj.relative_to(container_mountpoint)
     except ValueError as err:
         raise RuntimeError(errmsg_if_not_under_mountpoint) from err
 
     # I think we need to do this conversion to a PosixPath for the sake of Windows
     # machines, where relpath is a Windows-style path, but we want Posix paths for
-    # Docker. (But it may be that this is unnecessary.)
+    # container. (But it may be that this is unnecessary.)
     relpath_posix = pathlib.PurePosixPath(relpath)
 
     # In the following, we deliberately hard-code "/" rather than using something like
-    # os.path.join, because we need a path that works in Docker's file system, not the
+    # os.path.join, because we need a path that works in the container's file system, not the
     # native file system (in case the native file system is Windows).
-    return _DOCKER_HOME + "/" + str(relpath_posix)
+    return _CONTAINER_HOME + "/" + str(relpath_posix)

--- a/doc_builder/build_docs.py
+++ b/doc_builder/build_docs.py
@@ -15,6 +15,7 @@ import signal
 from doc_builder.build_commands import (
     get_build_dir,
     get_build_command,
+    get_container_cli_tool,
     DEFAULT_DOCKER_IMAGE,
 )
 from doc_builder.build_docs_shared_args import bd_dir_group, bd_parser
@@ -246,7 +247,7 @@ def setup_for_docker():
     def sigint_kill_docker(signum, frame):
         """Signal handler: kill docker process before exiting"""
         # pylint: disable=unused-argument
-        docker_kill_cmd = ["docker", "kill", docker_name]
+        docker_kill_cmd = [get_container_cli_tool(), "kill", docker_name]
         subprocess.check_call(docker_kill_cmd)
         sys.exit(1)
 

--- a/doc_builder/build_docs.py
+++ b/doc_builder/build_docs.py
@@ -16,7 +16,7 @@ from doc_builder.build_commands import (
     get_build_dir,
     get_build_command,
     get_container_cli_tool,
-    DEFAULT_DOCKER_IMAGE,
+    DEFAULT_IMAGE,
 )
 from doc_builder.build_docs_shared_args import bd_dir_group, bd_parser
 
@@ -47,7 +47,7 @@ This tool wraps the build command to build sphinx-based documentation.
 
 This tool assists with creating the correct documentation build commands
 in cases including:
-- Building the documentation from a Docker container
+- Building the documentation from a container
 - Building versioned documentation, where the documentation builds land
   in subdirectories named based on the source branch
 
@@ -61,7 +61,7 @@ Simple usage is:
 
     Common additional flags are:
     -c: Before building, run 'make clean'
-    -d: Use the {DEFAULT_DOCKER_IMAGE} Docker container to build the documentation
+    -d: Use the {DEFAULT_IMAGE} version of the container to build the documentation
 
 Usage for automatically determining the subdirectory in which to build,
 based on the version indicated by the current branch, is:
@@ -122,10 +122,9 @@ based on the version indicated by the current branch, is:
 
     parser.add_argument(
         "-i",
-        "--docker-image",
-        "--docker-container",
+        "--container-image",
         default=None,
-        help="Docker container to use. Implies -d.",
+        help="Container image version to use. Implies -d.",
     )
 
     parser.add_argument(
@@ -166,21 +165,21 @@ based on the version indicated by the current branch, is:
                 f"--site-root is neither a web URL nor an absolute path: '{options.site_root}'"
             )
 
-    if options.docker_image:
-        options.docker_image = options.docker_image.lower()
-        options.build_with_docker = True
-    elif options.build_with_docker:
-        options.docker_image = DEFAULT_DOCKER_IMAGE
+    if options.container_image:
+        options.container_image = options.container_image.lower()
+        options.build_in_container = True
+    elif options.build_in_container:
+        options.container_image = DEFAULT_IMAGE
 
     return options
 
 
-def setup_env_var(build_command, env, env_var, value, docker):
+def setup_env_var(build_command, env, env_var, value, container):
     """
-    Set up an environment variable, depending on whether using Docker or not
+    Set up an environment variable, depending on whether using container or not
     """
-    if docker:
-        # Need to pass to Docker via the build command
+    if container:
+        # Need to pass to container via the build command
         build_command.insert(-3, "-e")
         build_command.insert(-3, f"{env_var}={value}")
     else:
@@ -198,15 +197,15 @@ def run_build_command(build_command, version, options):
     else:
         value = version
     build_command, env = setup_env_var(
-        build_command, env, "version_display_name", value, options.build_with_docker
+        build_command, env, "version_display_name", value, options.build_in_container
     )
 
     # Set paths to certain directories
     build_command, env = setup_env_var(
-        build_command, env, "html_static_path", options.static_path, options.build_with_docker
+        build_command, env, "html_static_path", options.static_path, options.build_in_container
     )
     build_command, env = setup_env_var(
-        build_command, env, "templates_path", options.templates_path, options.build_with_docker
+        build_command, env, "templates_path", options.templates_path, options.build_in_container
     )
 
     # Things to do/set based on whether including version dropdown
@@ -217,7 +216,7 @@ def run_build_command(build_command, version, options):
             env,
             "pages_root",
             options.site_root,
-            options.build_with_docker,
+            options.build_in_container,
         )
     else:
         version_dropdown = ""
@@ -226,34 +225,36 @@ def run_build_command(build_command, version, options):
         env,
         "version_dropdown",
         version_dropdown,
-        options.build_with_docker,
+        options.build_in_container,
     )
 
     print(" ".join(build_command))
     subprocess.check_call(build_command, env=env)
 
 
-def setup_for_docker():
-    """Do some setup for running with docker
+def setup_for_container():
+    """Do some setup for running with container
 
-    Returns a name that should be used in the docker run command
+    Returns a name that should be used in the container run command
     """
 
-    docker_name = "build_docs_" + "".join(random.choice(string.ascii_lowercase) for _ in range(8))
+    container_name = "build_docs_" + "".join(
+        random.choice(string.ascii_lowercase) for _ in range(8)
+    )
 
-    # It seems that, if we kill the build_docs process with Ctrl-C, the docker process
+    # It seems that, if we kill the build_docs process with Ctrl-C, the container process
     # continues. Handle that by implementing a signal handler. There may be a better /
     # more pythonic way to handle this, but this should work.
-    def sigint_kill_docker(signum, frame):
-        """Signal handler: kill docker process before exiting"""
+    def sigint_kill_container(signum, frame):
+        """Signal handler: kill container process before exiting"""
         # pylint: disable=unused-argument
-        docker_kill_cmd = [get_container_cli_tool(), "kill", docker_name]
-        subprocess.check_call(docker_kill_cmd)
+        container_kill_cmd = [get_container_cli_tool(), "kill", container_name]
+        subprocess.check_call(container_kill_cmd)
         sys.exit(1)
 
-    signal.signal(signal.SIGINT, sigint_kill_docker)
+    signal.signal(signal.SIGINT, sigint_kill_container)
 
-    return docker_name
+    return container_name
 
 
 def main(cmdline_args=None):
@@ -264,14 +265,14 @@ def main(cmdline_args=None):
     """
     opts = commandline_options(cmdline_args)
 
-    if opts.build_with_docker:
-        # We potentially reuse the same docker name for multiple docker processes: the
+    if opts.build_in_container:
+        # We potentially reuse the same name for multiple container processes: the
         # clean and the actual build. However, since a given process should end before the
-        # next one begins, and because we use '--rm' in the docker run command, this
+        # next one begins, and because we use '--rm' in the container run command, this
         # should be okay.
-        docker_name = setup_for_docker()
+        container_name = setup_for_container()
     else:
-        docker_name = None
+        container_name = None
 
     # Note that we do a separate build for each version. This is
     # inefficient (assuming that the desired end result is for the
@@ -294,8 +295,8 @@ def main(cmdline_args=None):
                 build_target="clean",
                 num_make_jobs=opts.num_make_jobs,
                 version=version,
-                docker_name=docker_name,
-                docker_image=opts.docker_image,
+                container_name=container_name,
+                container_image=opts.container_image,
             )
             run_build_command(build_command=clean_command, version=version, options=opts)
 
@@ -305,8 +306,8 @@ def main(cmdline_args=None):
             build_target=opts.build_target,
             num_make_jobs=opts.num_make_jobs,
             version=version,
-            docker_name=docker_name,
-            docker_image=opts.docker_image,
+            container_name=container_name,
+            container_image=opts.container_image,
             warnings_as_warnings=opts.warnings_as_warnings,
             conf_py_path=opts.conf_py_path,
         )

--- a/doc_builder/build_docs_shared_args.py
+++ b/doc_builder/build_docs_shared_args.py
@@ -4,7 +4,7 @@ group.
 """
 
 # pylint: disable=import-error,no-name-in-module
-from .build_commands import DEFAULT_DOCKER_IMAGE
+from .build_commands import DEFAULT_IMAGE
 
 
 def bd_parser(parser, site_root_required=False):
@@ -20,19 +20,19 @@ def bd_parser(parser, site_root_required=False):
     )
     parser.add_argument(
         "-d",
-        "--build-with-docker",
+        "--build-in-container",
         action="store_true",
-        help="Use a Docker container to build the documentation,\n"
+        help="Use a container to build the documentation,\n"
         "rather than relying on locally-installed versions of Sphinx, etc.\n"
-        "This assumes that Docker is installed and running on your system.\n"
+        "This checks that a compatible container tool is installed and running on your system.\n"
         "\n"
-        "NOTE: This mounts your home directory in the Docker image.\n"
+        "NOTE: This mounts your home directory in the container.\n"
         "Therefore, both the current directory (containing the Makefile for\n"
         "building the documentation) and the documentation build directory\n"
         "must reside somewhere within your home directory."
         "\n"
-        f"Default image: {DEFAULT_DOCKER_IMAGE}\n"
-        "This can be changed with -i/--docker-image.",
+        f"Default image: {DEFAULT_IMAGE}\n"
+        "This can be changed with -i/--container-image.",
     )
     parser.add_argument(
         "--conf-py-path",

--- a/test/test_unit_get_build_command.py
+++ b/test/test_unit_get_build_command.py
@@ -102,9 +102,10 @@ class TestGetBuildCommand(unittest.TestCase):
             docker_name="foo",
             version="None",
             conf_py_path=conf_py_path,
+            container_cli_tool="abc123",
         )
         expected = [
-            "docker",
+            "abc123",
             "run",
             "--name",
             "foo",
@@ -140,9 +141,10 @@ class TestGetBuildCommand(unittest.TestCase):
             num_make_jobs=4,
             docker_name="foo",
             version="None",
+            container_cli_tool="abc123",
         )
         expected = [
-            "docker",
+            "abc123",
             "run",
             "--name",
             "foo",

--- a/test/test_unit_get_build_command.py
+++ b/test/test_unit_get_build_command.py
@@ -32,7 +32,7 @@ class TestGetBuildCommand(unittest.TestCase):
             run_from_dir="/irrelevant/path",
             build_target="html",
             num_make_jobs=4,
-            docker_name=None,
+            container_name=None,
             version="None",
         )
         expected = [
@@ -53,7 +53,7 @@ class TestGetBuildCommand(unittest.TestCase):
             run_from_dir="/irrelevant/path",
             build_target="html",
             num_make_jobs=4,
-            docker_name=None,
+            container_name=None,
             version="None",
             conf_py_path=conf_py_path,
         )
@@ -75,7 +75,7 @@ class TestGetBuildCommand(unittest.TestCase):
             run_from_dir="/irrelevant/path",
             build_target="html",
             num_make_jobs=4,
-            docker_name=None,
+            container_name=None,
             version="None",
             conf_py_path=conf_py_path,
         )
@@ -90,8 +90,8 @@ class TestGetBuildCommand(unittest.TestCase):
         self.assertEqual(expected, build_command)
 
     @patch("os.path.expanduser")
-    def test_docker(self, mock_expanduser):
-        """Tests usage with use_docker=True"""
+    def test_container(self, mock_expanduser):
+        """Tests usage with container"""
         mock_expanduser.return_value = "/path/to/username"
         conf_py_path = os.path.join(os.path.dirname(__file__), "conf.py")
         build_command = get_build_command(
@@ -99,7 +99,7 @@ class TestGetBuildCommand(unittest.TestCase):
             run_from_dir="/path/to/username/foorepos/foocode/doc",
             build_target="html",
             num_make_jobs=4,
-            docker_name="foo",
+            container_name="foo",
             version="None",
             conf_py_path=conf_py_path,
             container_cli_tool="abc123",
@@ -131,15 +131,15 @@ class TestGetBuildCommand(unittest.TestCase):
         self.assertEqual(expected, build_command)
 
     @patch("os.path.expanduser")
-    def test_docker_relpath(self, mock_expanduser):
-        """Tests usage with use_docker=True, with a relative path to build_dir"""
+    def test_container_relpath(self, mock_expanduser):
+        """Tests usage with container, with a relative path to build_dir"""
         mock_expanduser.return_value = "/path/to/username"
         build_command = get_build_command(
             build_dir="../../foodocs/versions/main",
             run_from_dir="/path/to/username/foorepos/foocode/doc",
             build_target="html",
             num_make_jobs=4,
-            docker_name="foo",
+            container_name="foo",
             version="None",
             container_cli_tool="abc123",
         )
@@ -169,7 +169,7 @@ class TestGetBuildCommand(unittest.TestCase):
         self.assertEqual(expected, build_command)
 
     @patch("os.path.expanduser")
-    def test_docker_builddir_not_in_home(self, mock_expanduser):
+    def test_container_builddir_not_in_home(self, mock_expanduser):
         """If build_dir is not in the user's home directory, should raise an exception"""
         mock_expanduser.return_value = "/path/to/username"
         with self.assertRaisesRegex(
@@ -180,12 +180,12 @@ class TestGetBuildCommand(unittest.TestCase):
                 run_from_dir="/path/to/username/foorepos/foocode/doc",
                 build_target="html",
                 num_make_jobs=4,
-                docker_name="foo",
+                container_name="foo",
                 version="None",
             )
 
     @patch("os.path.expanduser")
-    def test_docker_runfromdir_not_in_home(self, mock_expanduser):
+    def test_container_runfromdir_not_in_home(self, mock_expanduser):
         """If run_from_dir is not in the user's home directory, should raise an exception"""
         mock_expanduser.return_value = "/path/to/username"
         with self.assertRaisesRegex(
@@ -197,7 +197,7 @@ class TestGetBuildCommand(unittest.TestCase):
                 run_from_dir="/path/to/other/foorepos/foocode/doc",
                 build_target="html",
                 num_make_jobs=4,
-                docker_name="foo",
+                container_name="foo",
                 version="None",
             )
 


### PR DESCRIPTION
`build_docs*` scripts now try `podman` first, and if that's not found, fall back to `docker`.