### PR TITLE
Prefer Podman on Mac, Docker Engine elsewhere

### DIFF
--- a/build_docs_to_publish
+++ b/build_docs_to_publish
@@ -130,6 +130,9 @@ def reset_git(orig_ref):
     result = subprocess.run(cmd, check=False, capture_output=True, text=True)
     # If doc-builder not tracked by git, that's fine. Otherwise error.
     if result.returncode and "did not match any file(s) known to git" not in result.stderr:
+        print("PWD: " + os.getcwd())
+        print(result.stdout)
+        print(result.stderr)
         raise subprocess.CalledProcessError(result.returncode, cmd)
 
     # 2. Check out the original git ref (branch or commit SHA)

--- a/build_docs_to_publish
+++ b/build_docs_to_publish
@@ -19,7 +19,13 @@ from doc_builder.build_docs import (
     main as build_docs,
 )
 from doc_builder.build_docs_shared_args import main as build_docs_shared_args
-from doc_builder.sys_utils import get_git_head_or_branch, check_permanent_file, get_toplevel_git_dir
+from doc_builder.sys_utils import (
+    get_git_head_or_branch,
+    check_permanent_file,
+    get_toplevel_git_dir,
+    is_mac,
+)
+from doc_builder.build_commands import get_container_cli_tool
 
 # Change to the parent director of doc-builder and add to Python path
 os.chdir(os.path.join(os.path.dirname(__file__), os.pardir))
@@ -178,6 +184,15 @@ def main():
 
     # Check version list for problems
     check_version_list()
+
+    # build_docs_to_publish has trouble on Linux (maybe just Ubuntu?) with Podman. Only allow
+    # Docker. Issue filed: https://github.com/ESMCI/doc-builder/issues/27
+    if args.container_cli_tool is None:
+        args.container_cli_tool = get_container_cli_tool()
+    if args.container_cli_tool == "podman" and not is_mac():
+        raise RuntimeError(
+            "build_docs_to_publish is only supported for Podman on Macs. Use Docker instead."
+        )
 
     # Loop over all documentation versions
     for version in VERSION_LIST:

--- a/doc_builder/build_docs.py
+++ b/doc_builder/build_docs.py
@@ -8,7 +8,6 @@ import os
 import random
 import string
 import sys
-import platform
 from urllib.parse import urlparse
 import signal
 
@@ -20,6 +19,7 @@ from doc_builder.build_commands import (
     DEFAULT_IMAGE,
 )
 from doc_builder.build_docs_shared_args import bd_dir_group, bd_parser
+from doc_builder.sys_utils import is_mac
 
 
 def is_web_url(url_string):
@@ -245,7 +245,7 @@ def run_build_command(build_command, version, options):
     # Start container software/VM
     if "podman" in build_command:
         start_container_software("podman machine start")
-    elif "docker" in build_command and platform.system() == "Darwin":  # Darwin means Mac
+    elif "docker" in build_command and is_mac():
         start_container_software("docker desktop start")
 
     print(" ".join(build_command))

--- a/doc_builder/sys_utils.py
+++ b/doc_builder/sys_utils.py
@@ -4,6 +4,7 @@ Functions that wrap system calls, including calls to the OS, git, etc.
 
 import subprocess
 import os
+import platform
 
 
 def check_permanent_file(filepath):
@@ -131,6 +132,11 @@ def git_current_branch():
             branch_name = branch_name.strip()
 
     return branch_found, branch_name
+
+
+def is_mac():
+    """Returns True if running on a Mac"""
+    return platform.system() == "Darwin"
 
 
 def is_under(child, parent_dir):

--- a/test/test_unit_get_build_command.py
+++ b/test/test_unit_get_build_command.py
@@ -5,7 +5,8 @@
 import os
 import unittest
 from unittest.mock import patch
-from doc_builder.build_commands import get_build_command  # pylint: disable=import-error
+# pylint: disable=import-error
+from doc_builder.build_commands import get_build_command, get_mount_arg
 
 # Allow names that pylint doesn't like, because otherwise I find it hard
 # to make readable unit test names
@@ -118,6 +119,7 @@ class TestGetBuildCommand(unittest.TestCase):
             conf_py_path=conf_py_path,
             container_cli_tool="abc123",
         )
+        mount_option, mount_arg = get_mount_arg("/path/to/username")
         expected = [
             "abc123",
             "run",
@@ -125,8 +127,8 @@ class TestGetBuildCommand(unittest.TestCase):
             "foo",
             "--user",
             self.uid_gid,
-            "-v",
-            "/path/to/username:/home/user/mounted_home:U",
+            mount_option,
+            mount_arg,
             "--workdir",
             "/home/user/mounted_home/foorepos/foocode/doc",
             "-t",
@@ -157,6 +159,7 @@ class TestGetBuildCommand(unittest.TestCase):
             version="None",
             container_cli_tool="abc123",
         )
+        mount_option, mount_arg = get_mount_arg("/path/to/username")
         expected = [
             "abc123",
             "run",
@@ -164,8 +167,8 @@ class TestGetBuildCommand(unittest.TestCase):
             "foo",
             "--user",
             self.uid_gid,
-            "-v",
-            "/path/to/username:/home/user/mounted_home:U",
+            mount_option,
+            mount_arg,
             "--workdir",
             "/home/user/mounted_home/foorepos/foocode/doc",
             "-t",
@@ -197,14 +200,15 @@ class TestGetBuildCommand(unittest.TestCase):
             conf_py_path=conf_py_path,
             container_cli_tool=None,
         )
+        mount_option, mount_arg = get_mount_arg("/path/to/username")
         expected = [
             "run",
             "--name",
             "foo",
             "--user",
             self.uid_gid,
-            "-v",
-            "/path/to/username:/home/user/mounted_home:U",
+            mount_option,
+            mount_arg,
             "--workdir",
             "/home/user/mounted_home/foorepos/foocode/doc",
             "-t",

--- a/test/test_unit_get_build_command.py
+++ b/test/test_unit_get_build_command.py
@@ -5,8 +5,9 @@
 import os
 import unittest
 from unittest.mock import patch
+
 # pylint: disable=import-error
-from doc_builder.build_commands import get_build_command, get_mount_arg
+from doc_builder.build_commands import get_build_command, get_mount_arg, get_container_cli_tool
 
 # Allow names that pylint doesn't like, because otherwise I find it hard
 # to make readable unit test names
@@ -224,9 +225,7 @@ class TestGetBuildCommand(unittest.TestCase):
             "html",
         ]
         print("build_command: +", " ".join(build_command))
-        self.assertTrue(
-            build_command in [["podman"] + expected, build_command == ["docker"] + expected]
-        )
+        self.assertEqual(build_command, [get_container_cli_tool()] + expected)
 
     @patch("doc_builder.sys_utils.get_toplevel_of_doc_builder_parent")
     def test_container_builddir_not_in_db_checkout(self, mock_get_toplevel_of_doc_builder_parent):


### PR DESCRIPTION
- Use --mount instead of -v where possible (on Mac, or Ubuntu Docker).
- Don't allow build_docs_to_publish with Podman except on Mac. See ESMCI/doc-builder#27.