### PR TITLE
Improve verbosity filter

### DIFF
--- a/doc_builder/output_utils.py
+++ b/doc_builder/output_utils.py
@@ -2,7 +2,9 @@
 
 import re
 
-_SPHINX_COMPLAINT_PATTERN = re.compile(r"^.*(?:WARNING|ERROR|CRITICAL).*$", re.MULTILINE)
+# Requiring at least one character before the keyword prevents the "WARNING: image platform ...
+# does not match the expected platform ..." message from matching.
+_SPHINX_COMPLAINT_PATTERN = re.compile(r"^.+(?:WARNING|ERROR|CRITICAL).*$", re.MULTILINE)
 
 
 def extract_sphinx_complaints(*outputs):

--- a/doc_builder/output_utils.py
+++ b/doc_builder/output_utils.py
@@ -2,7 +2,7 @@
 
 import re
 
-_SPHINX_COMPLAINT_PATTERN = re.compile(r"^.*(?:WARNING|ERROR).*$", re.MULTILINE)
+_SPHINX_COMPLAINT_PATTERN = re.compile(r"^.*(?:WARNING|ERROR|CRITICAL).*$", re.MULTILINE)
 
 
 def extract_sphinx_complaints(*outputs):

--- a/test/test_unit_output_utils.py
+++ b/test/test_unit_output_utils.py
@@ -10,7 +10,9 @@ from doc_builder.output_utils import extract_sphinx_complaints  # pylint: disabl
 _WARNING_WITH_LOCATION = (
     "/path/to/file.rst:42: WARNING: toctree contains reference to nonexisting document 'missing'"
 )
+_CRITICAL_WITH_LOCATION = "/path/to/file.rst:42: CRITICAL: Duplicate ID: 'equation-n-cost-fix'"
 _WARNING_WITHOUT_LOCATION = "WARNING: unknown config value 'foo'"
+_CRITICAL_WITHOUT_LOCATION = "CRITICAL: Duplicate ID: 'equation-n-cost-fix'"
 _ERROR_WITH_LOCATION = "/path/to/file.rst:10: ERROR: unknown directive type 'bogus'"
 _ERROR_WITHOUT_LOCATION = "ERROR: master file not found"
 
@@ -54,6 +56,16 @@ class TestExtractSphinxComplaints(unittest.TestCase):
         """Captures ERROR lines without file:line prefix"""
         output = "\n".join(_NORMAL_LINES + [_ERROR_WITHOUT_LOCATION])
         self.assertEqual(extract_sphinx_complaints(output), [_ERROR_WITHOUT_LOCATION])
+
+    def test_critical_with_location(self):
+        """Captures CRITICAL lines with file:line prefix"""
+        output = "\n".join(_NORMAL_LINES + [_CRITICAL_WITH_LOCATION])
+        self.assertEqual(extract_sphinx_complaints(output), [_CRITICAL_WITH_LOCATION])
+
+    def test_critical_without_location(self):
+        """Does *not* capture CRITICAL lines without file:line prefix"""
+        output = "\n".join(_NORMAL_LINES + [_CRITICAL_WITHOUT_LOCATION])
+        self.assertEqual(extract_sphinx_complaints(output), [])
 
     def test_multiple_complaints(self):
         """Extracts multiple complaint lines in order"""

--- a/test/test_unit_output_utils.py
+++ b/test/test_unit_output_utils.py
@@ -43,9 +43,9 @@ class TestExtractSphinxComplaints(unittest.TestCase):
         self.assertEqual(extract_sphinx_complaints(output), [_WARNING_WITH_LOCATION])
 
     def test_warning_without_location(self):
-        """Captures WARNING lines without file:line prefix"""
+        """Does *not* capture WARNING lines without file:line prefix"""
         output = "\n".join(_NORMAL_LINES + [_WARNING_WITHOUT_LOCATION])
-        self.assertEqual(extract_sphinx_complaints(output), [_WARNING_WITHOUT_LOCATION])
+        self.assertEqual(extract_sphinx_complaints(output), [])
 
     def test_error_with_location(self):
         """Captures ERROR lines with file:line prefix"""
@@ -53,9 +53,9 @@ class TestExtractSphinxComplaints(unittest.TestCase):
         self.assertEqual(extract_sphinx_complaints(output), [_ERROR_WITH_LOCATION])
 
     def test_error_without_location(self):
-        """Captures ERROR lines without file:line prefix"""
+        """Does *not* capture ERROR lines without file:line prefix"""
         output = "\n".join(_NORMAL_LINES + [_ERROR_WITHOUT_LOCATION])
-        self.assertEqual(extract_sphinx_complaints(output), [_ERROR_WITHOUT_LOCATION])
+        self.assertEqual(extract_sphinx_complaints(output), [])
 
     def test_critical_with_location(self):
         """Captures CRITICAL lines with file:line prefix"""
@@ -81,16 +81,15 @@ class TestExtractSphinxComplaints(unittest.TestCase):
         expected = [
             _WARNING_WITH_LOCATION,
             _ERROR_WITH_LOCATION,
-            _WARNING_WITHOUT_LOCATION,
         ]
         self.assertEqual(extract_sphinx_complaints(output), expected)
 
     def test_combines_stdout_and_stderr(self):
         """When given two strings, extracts from both in order"""
         stdout = "\n".join([_NORMAL_LINES[0], _WARNING_WITH_LOCATION])
-        stderr = "\n".join([_ERROR_WITHOUT_LOCATION, _NORMAL_LINES[1]])
+        stderr = "\n".join([_ERROR_WITH_LOCATION, _NORMAL_LINES[1]])
         result = extract_sphinx_complaints(stdout, stderr)
-        self.assertEqual(result, [_WARNING_WITH_LOCATION, _ERROR_WITHOUT_LOCATION])
+        self.assertEqual(result, [_WARNING_WITH_LOCATION, _ERROR_WITH_LOCATION])
 
     def test_zero_arguments(self):
         """Calling with zero arguments returns empty list"""

--- a/test/test_unit_run_build_command.py
+++ b/test/test_unit_run_build_command.py
@@ -37,7 +37,7 @@ _SPHINX_STDOUT_WITH_WARNINGS = (
     "writing output... [100%] index\n"
     "WARNING: unknown config value 'bogus'\n"
 )
-_SPHINX_STDERR_WITH_ERROR = "ERROR: master file not found\n"
+_SPHINX_STDERR_WITH_ERROR = "/path/to/file.rst:42: ERROR: master file not found\n"
 _SPHINX_STDERR_FINISHED_WITH_PROBLEMS = (
     "WARNING: unknown config value 'bogus'\n" + _SPHINX_BUILD_FINISHED_WITH_PROBLEMS + "\n"
 )
@@ -109,7 +109,7 @@ class TestRunBuildCommandOutput(unittest.TestCase):
                 run_build_command(_FAKE_COMMAND, _FAKE_VERSION, opts)
         combined = mock_stdout.getvalue() + mock_stderr.getvalue()
         self.assertIn("WARNING: toctree contains reference", combined)
-        self.assertIn("WARNING: unknown config value", combined)
+        self.assertNotIn("WARNING: unknown config value", combined)  # Because WARNING at line start
         self.assertIn("ERROR: master file not found", combined)
         # Should NOT contain normal Sphinx noise
         self.assertNotIn("Running Sphinx", combined)


### PR DESCRIPTION
When not verbose:
- Capture `CRITICAL` messages
- Suppress "image platform does not match expected" warning