### PR TITLE
Improve table captions

### DIFF
--- a/_static/caption-fix.js
+++ b/_static/caption-fix.js
@@ -1,7 +1,9 @@
 (function () {
     function moveCaptions() {
         document.querySelectorAll("table").forEach(function (table) {
-            var caption = table.querySelector("caption");
+            var caption = Array.prototype.find.call(table.children, function (c) {
+                return c.tagName === "CAPTION";
+            });
             if (!caption) return;
             // insert above the wrapper if one exists, else above the table itself
             var target = table.closest(".wy-table-responsive") || table;

--- a/_static/caption-fix.js
+++ b/_static/caption-fix.js
@@ -1,6 +1,6 @@
 (function () {
     function moveCaptions() {
-        document.querySelectorAll("table.left-caption").forEach(function (table) {
+        document.querySelectorAll("table").forEach(function (table) {
             var caption = table.querySelector("caption");
             if (!caption) return;
             // insert above the wrapper if one exists, else above the table itself

--- a/_static/caption-fix.js
+++ b/_static/caption-fix.js
@@ -1,0 +1,20 @@
+(function () {
+    function moveCaptions() {
+        document.querySelectorAll("table.left-caption").forEach(function (table) {
+            var caption = table.querySelector("caption");
+            if (!caption) return;
+            // insert above the wrapper if one exists, else above the table itself
+            var target = table.closest(".wy-table-responsive") || table;
+            var ext = document.createElement("div");
+            ext.className = "table-caption-external";
+            ext.innerHTML = caption.innerHTML;
+            target.parentNode.insertBefore(ext, target);
+            caption.remove();
+        });
+    }
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", moveCaptions);
+    } else {
+        moveCaptions();
+    }
+})();

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -21,3 +21,12 @@
     margin-bottom: 0.5em;
     /* ordinary block — caps at content width, never enters the scroll region */
 }
+.table-caption-external .headerlink {
+    visibility: hidden;
+    margin-left: 0.3em;
+    text-decoration: none;
+    font-family: FontAwesome;
+}
+.table-caption-external:hover .headerlink {
+    visibility: visible;
+}

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -15,3 +15,9 @@
     /* Place link in margin and keep equation number aligned with boundary */
     margin-right: -0.7em;
 }
+.table-caption-external {
+    text-align: left;
+    font-style: italic;
+    margin-bottom: 0.5em;
+    /* ordinary block — caps at content width, never enters the scroll region */
+}

--- a/conf.py
+++ b/conf.py
@@ -200,6 +200,7 @@ numfig_secnum_depth = 2
 
 def setup(app):
     app.add_css_file('css/custom.css')
+    app.add_js_file('caption-fix.js')
 
 try:
     html_context


### PR DESCRIPTION
All table captions are now
- Left-aligned,
- Sticky (i.e., they don't move as you scroll horizontally in the table, and
- Limited to the size of the content column.